### PR TITLE
Enable CORS policy in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,16 @@
       "src": "/(.*)",
       "dest": "api/main.py"
     }
+  ],
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Credentials", "value": "true" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
+        { "key": "Access-Control-Allow-Headers", "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" }
+      ]
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
-  "routes": [
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "api/main.py"
+      "source": "/(.*)",
+      "destination": "api/main.py"
     }
   ],
   "headers": [


### PR DESCRIPTION
# Description
React/Next webapps won't have access without CORS policy.

# Requirements
1. Enable CORS for Vercel serverless functions