### PR TITLE
implement nonprofits API

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,7 @@ main module
 
 from fastapi import FastAPI
 
-from routes import auth_route_v1, litigations_route_v1, users_route_v1, home_route_v1, experts_route_v1
+from routes import auth_route_v1, litigations_route_v1, nonprofits_route_v1, users_route_v1, home_route_v1, experts_route_v1
 from routes.middleware import AuthMiddleware
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -24,6 +24,7 @@ def create_app():
     fastapi.include_router(litigations_route_v1.router, prefix="/v1")
     fastapi.include_router(home_route_v1.router, prefix="/v1")
     fastapi.include_router(experts_route_v1.router, prefix="/v1")
+    fastapi.include_router(nonprofits_route_v1.router, prefix="/v1")
     return fastapi
 
 

--- a/routes/experts_route_v1.py
+++ b/routes/experts_route_v1.py
@@ -1,4 +1,3 @@
-
 """
 experts data operations route v1
 """

--- a/routes/nonprofits_route_v1.py
+++ b/routes/nonprofits_route_v1.py
@@ -1,0 +1,49 @@
+
+"""
+experts data operations route v1
+"""
+
+from fastapi import APIRouter, Depends
+from data.database_repository import DatabaseRepository
+
+router = APIRouter(
+    prefix="/nonprofits",
+    tags=["nonprofits"],
+    responses={404: {"description": "Not found"}}
+)
+
+def get_database_repository() -> DatabaseRepository:
+    """
+    dependency to get the DatabaseRepository instance.
+    This allows for easy testing and mocking of the repository.
+    """
+    return DatabaseRepository()
+
+@router.get("/")
+async def get_nonprofits(page_number: int = 1, page_size: int = 10, repository: DatabaseRepository = Depends(get_database_repository)):
+    """
+    retrieve all nonprofits with pagination
+    :param page_number: the page number to fetch
+    :param page_size: the number of items per page
+    """
+    try:
+        nonprofits = await repository.get_nonprofits(page_number=page_number, page_size=page_size)
+        return {"data": nonprofits}
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"Error fetching paged nonprofits: {e}")
+        return {"message": "Error fetching paged nonprofits"}
+
+
+@router.get("/{nonprofit_id}")
+async def get_nonprofit_by_id(nonprofit_id: str, repository: DatabaseRepository = Depends(get_database_repository)):
+    """
+    retrieve nonprofit by id
+    """
+    try:
+        nonprofit = await repository.get_entity_by_nonprofit_id(nonprofit_id)
+        if nonprofit is None:
+            return {"message": "Nonprofit not found"}
+        return {"data": nonprofit}
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"Error fetching nonprofit by id: {e}")
+        return {"message": "Error fetching nonprofit by id"}

--- a/tests/unit_tests/test_nonprofits_route.py
+++ b/tests/unit_tests/test_nonprofits_route.py
@@ -1,0 +1,79 @@
+"""
+unit tests for the nonprofits route
+"""
+
+from fastapi.testclient import TestClient
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from api.main import app
+from data.database_repository import DatabaseRepository
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_database_repository():
+    """
+    Mock DatabaseRepository for testing.
+    """
+    mock_repo = MagicMock(spec=DatabaseRepository)
+    mock_repo.get_experts = AsyncMock()
+    mock_repo.get_expert_by_id = AsyncMock()
+    return mock_repo
+
+def test_get_nonprofits(mocker):
+    """
+    Test the get_nonprofits endpoint.
+    """
+    mock_nonprofits = [
+        {"id": "1", "name": "Nonprofit One"}, 
+        {"id": "2", "name": "Nonprofit Two"}
+    ]
+    mocker.patch(
+        "routes.nonprofits_route_v1.DatabaseRepository.get_nonprofits",
+        return_value=mock_nonprofits
+    )
+
+    response = client.get("/v1/nonprofits/")
+    assert response.status_code == 200
+    assert response.json() == {"data": mock_nonprofits}
+
+def test_get_entity_by_nonprofit_id(mocker):
+    """
+    Test the get_entity_by_nonprofit_id endpoint.
+    """
+    mock_nonprofit = {"id": "1", "name": "Nonprofit One"}
+    mocker.patch(
+        "routes.nonprofits_route_v1.DatabaseRepository.get_entity_by_nonprofit_id",
+        return_value=mock_nonprofit
+    )
+
+    response = client.get("/v1/nonprofits/1")
+    assert response.status_code == 200
+    assert response.json() == {"data": {"id": "1", "name": "Nonprofit One"}}
+
+def test_get_nonprofits_error(mocker):
+    """
+    Test error handling in get_nonprofits endpoint.
+    """
+    # Mock an exception in the repository method
+    mocker.patch(
+        "routes.nonprofits_route_v1.DatabaseRepository.get_nonprofits",
+        side_effect=Exception("Database error")
+    )
+
+    response = client.get("/v1/nonprofits/?page_number=1&page_size=10")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Error fetching paged nonprofits"}
+
+def test_get_entity_by_nonprofit_id_error(mocker):
+    """
+    Test error handling in get_entity_by_nonprofit_id endpoint.
+    """
+    mocker.patch(
+        "routes.nonprofits_route_v1.DatabaseRepository.get_entity_by_nonprofit_id",
+        side_effect=Exception("Error fetching nonprofit by id")
+    )
+
+    response = client.get("/v1/nonprofits/1")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Error fetching nonprofit by id"}


### PR DESCRIPTION
# Description
Implementation of `v1/nonprofits/` and `v1/nonprofits/{nonprofit_id}` APIs.

# Features
- New `/v1/nonprofits/` endpoint that returns a paginated response of entity data (default to 10 items)
- New `/v1/nonprofits/{nonprofit_id}` endpoint that return entity data based on given nonprofit id